### PR TITLE
urlparse was breaking python3+ compat

### DIFF
--- a/pusher/__init__.py
+++ b/pusher/__init__.py
@@ -9,12 +9,11 @@ import hmac
 import json
 import hashlib
 try:
-    from urllib.parse import quote
+    import urllib.parse as urlparse
 except ImportError:
-    from urllib import quote
+    import urlparse
 import re
 import socket
-import urlparse
 
 if sys.version < '3':
     text_type = unicode

--- a/pusher/__init__.py
+++ b/pusher/__init__.py
@@ -10,6 +10,7 @@ import json
 import hashlib
 try:
     import urllib.parse as urlparse
+    from urllib.parse import quote
 except ImportError:
     import urlparse
 import re


### PR DESCRIPTION
Pull 27 added Python 3* compat, a later pull broke it (urlparse was replaced in python 3)