### PR TITLE
Restore python3 support

### DIFF
--- a/pusher/__init__.py
+++ b/pusher/__init__.py
@@ -14,7 +14,10 @@ except ImportError:
     from urllib import quote
 import re
 import socket
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
 
 if sys.version < '3':
     text_type = unicode


### PR DESCRIPTION
This restore python3 support, wich was dropped in [this](https://github.com/pusher/pusher_client_python/commit/9f20c11b688702099e592846e80ee723af44c5cb) commit. 

Please, check code before merge to master for support both python versions, because it hard to use this library when it can suddenly break.